### PR TITLE
Upgrade terraform-plugin-framework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,8 @@ website/node_modules
 
 website/vendor
 
+.vscode
+
 # Test exclusions
 !command/test-fixtures/**/*.tfstate
 !command/test-fixtures/**/.terraform/

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/hashicorp/terraform-plugin-docs v0.13.0
-	github.com/hashicorp/terraform-plugin-framework v0.11.1
+	github.com/hashicorp/terraform-plugin-framework v0.14.0
 	github.com/hashicorp/terraform-plugin-framework-validators v0.5.0
 	github.com/hashicorp/terraform-plugin-go v0.14.0
 	github.com/hashicorp/terraform-plugin-log v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -600,8 +600,8 @@ github.com/hashicorp/terraform-json v0.14.0 h1:sh9iZ1Y8IFJLx+xQiKHGud6/TSUCM0N8e
 github.com/hashicorp/terraform-json v0.14.0/go.mod h1:5A9HIWPkk4e5aeeXIBbkcOvaZbIYnAIkEyqP2pNSckM=
 github.com/hashicorp/terraform-plugin-docs v0.13.0 h1:6e+VIWsVGb6jYJewfzq2ok2smPzZrt1Wlm9koLeKazY=
 github.com/hashicorp/terraform-plugin-docs v0.13.0/go.mod h1:W0oCmHAjIlTHBbvtppWHe8fLfZ2BznQbuv8+UD8OucQ=
-github.com/hashicorp/terraform-plugin-framework v0.11.1 h1:rq8f+TLDO4tJu+n9mMYlDrcRoIdrg0gTUvV2Jr0Ya24=
-github.com/hashicorp/terraform-plugin-framework v0.11.1/go.mod h1:GENReHOz6GEt8Jk3UN94vk8BdC6irEHFgN3Z9HPhPUU=
+github.com/hashicorp/terraform-plugin-framework v0.14.0 h1:Mwj55u+Jc/QGM6fLBPCe1P+ZF3cuYs6wbCdB15lx/Dg=
+github.com/hashicorp/terraform-plugin-framework v0.14.0/go.mod h1:wcZdk4+Uef6Ng+BiBJjGAcIPlIs5bhlEV/TA1k6Xkq8=
 github.com/hashicorp/terraform-plugin-framework-validators v0.5.0 h1:eD79idhnJOBajkUMEbm0c8dOyOb/F49STbUEVojT6F4=
 github.com/hashicorp/terraform-plugin-framework-validators v0.5.0/go.mod h1:NfGgclDM3FZqvNVppPKE2aHI1JAyT002ypPRya7ch3I=
 github.com/hashicorp/terraform-plugin-go v0.14.0 h1:ttnSlS8bz3ZPYbMb84DpcPhY4F5DsQtcAS7cHo8uvP4=

--- a/internal/provider/datasource_k3d_nodes.go
+++ b/internal/provider/datasource_k3d_nodes.go
@@ -7,7 +7,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
-	"github.com/hashicorp/terraform-plugin-framework/provider"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -17,10 +16,7 @@ import (
 )
 
 // Ensure provider defined types fully satisfy framework interfaces
-var _ provider.DataSourceType = k3dNodesDataSourceType{}
 var _ datasource.DataSource = k3dNodesDataSource{}
-
-type k3dNodesDataSourceType struct{}
 
 var portBindingType = types.ObjectType{
 	AttrTypes: map[string]attr.Type{
@@ -30,7 +26,101 @@ var portBindingType = types.ObjectType{
 	},
 }
 
-func (t k3dNodesDataSourceType) GetSchema(ctx context.Context) (tfsdk.Schema, diag.Diagnostics) {
+type k3dNodesData struct {
+	ClusterName types.String       `tfsdk:"cluster_name"`
+	Id          types.String       `tfsdk:"id"`
+	Nodes       map[string]k3dNode `tfsdk:"nodes"`
+}
+
+type k3dNode struct {
+	Name          string            `tfsdk:"name"`
+	Role          string            `tfsdk:"role"`
+	Ports         []k3dPort         `tfsdk:"ports"`
+	RuntimeLabels map[string]string `tfsdk:"runtime_labels"`
+	NodeLabels    map[string]string `tfsdk:"node_labels"`
+	Networks      []string          `tfsdk:"networks"`
+	IP            string            `tfsdk:"ip"`
+}
+
+type k3dPort struct {
+	Port     int64  `tfsdk:"port"`
+	HostIP   string `tfsdk:"host_ip"`
+	HostPort int64  `tfsdk:"host_port"`
+}
+
+type k3dNodesDataSource struct {
+}
+
+func NewNodesDataSource() datasource.DataSource {
+	return k3dNodesDataSource{}
+}
+
+func (d k3dNodesDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var data k3dNodesData
+
+	diags := req.Config.Get(ctx, &data)
+	resp.Diagnostics.Append(diags...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	nodes, err := client.NodeList(ctx, runtimes.SelectedRuntime)
+	if err != nil {
+		resp.Diagnostics.Append(diag.NewErrorDiagnostic("Failed to lister K3d nodes", err.Error()))
+		return
+	}
+
+	newNodes := make(map[string]k3dNode)
+	for _, node := range nodes {
+		// filter out nodes for other K3D clusters
+		cluster, ok := node.RuntimeLabels["k3d.cluster"]
+		if !ok || cluster != data.ClusterName.Value {
+			continue
+		}
+
+		var ports []k3dPort
+
+		for port, bindings := range node.Ports {
+			for _, binding := range bindings {
+				hostPort, err := strconv.ParseInt(binding.HostPort, 10, 16)
+				if err != nil {
+					continue
+				}
+
+				ports = append(ports, k3dPort{
+					Port:     int64(port.Int()),
+					HostIP:   binding.HostIP,
+					HostPort: hostPort,
+				})
+			}
+		}
+
+		newNodes[node.Name] = k3dNode{
+			Name:          node.Name,
+			Role:          string(node.Role),
+			Ports:         ports,
+			RuntimeLabels: node.RuntimeLabels,
+			NodeLabels:    node.K3sNodeLabels,
+			Networks:      node.Networks,
+			IP:            node.IP.IP.String(),
+		}
+	}
+
+	// For the purposes of this example code, hardcoding a response value to
+	// save into the Terraform state.
+	data.Id = data.ClusterName
+	data.Nodes = newNodes
+
+	diags = resp.State.Set(ctx, &data)
+	resp.Diagnostics.Append(diags...)
+}
+
+func (t k3dNodesDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_nodes"
+}
+
+func (t k3dNodesDataSource) GetSchema(ctx context.Context) (tfsdk.Schema, diag.Diagnostics) {
 	return tfsdk.Schema{
 		// This description is used by the documentation generator and the language server.
 		MarkdownDescription: "K3d Cluster Node Listing Data Source",
@@ -106,99 +196,4 @@ func (t k3dNodesDataSourceType) GetSchema(ctx context.Context) (tfsdk.Schema, di
 			},
 		},
 	}, nil
-}
-
-func (t k3dNodesDataSourceType) NewDataSource(ctx context.Context, in provider.Provider) (datasource.DataSource, diag.Diagnostics) {
-	provider, diags := convertProviderType(in)
-
-	return k3dNodesDataSource{
-		provider: provider,
-	}, diags
-}
-
-type k3dNodesData struct {
-	ClusterName types.String       `tfsdk:"cluster_name"`
-	Id          types.String       `tfsdk:"id"`
-	Nodes       map[string]k3dNode `tfsdk:"nodes"`
-}
-
-type k3dNode struct {
-	Name          string            `tfsdk:"name"`
-	Role          string            `tfsdk:"role"`
-	Ports         []k3dPort         `tfsdk:"ports"`
-	RuntimeLabels map[string]string `tfsdk:"runtime_labels"`
-	NodeLabels    map[string]string `tfsdk:"node_labels"`
-	Networks      []string          `tfsdk:"networks"`
-	IP            string            `tfsdk:"ip"`
-}
-
-type k3dPort struct {
-	Port     int64  `tfsdk:"port"`
-	HostIP   string `tfsdk:"host_ip"`
-	HostPort int64  `tfsdk:"host_port"`
-}
-
-type k3dNodesDataSource struct {
-	provider k3dProvider
-}
-
-func (d k3dNodesDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
-	var data k3dNodesData
-
-	diags := req.Config.Get(ctx, &data)
-	resp.Diagnostics.Append(diags...)
-
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
-	nodes, err := client.NodeList(ctx, runtimes.SelectedRuntime)
-	if err != nil {
-		resp.Diagnostics.Append(diag.NewErrorDiagnostic("Failed to lister K3d nodes", err.Error()))
-		return
-	}
-
-	newNodes := make(map[string]k3dNode)
-	for _, node := range nodes {
-		// filter out nodes for other K3D clusters
-		cluster, ok := node.RuntimeLabels["k3d.cluster"]
-		if !ok || cluster != data.ClusterName.Value {
-			continue
-		}
-
-		var ports []k3dPort
-
-		for port, bindings := range node.Ports {
-			for _, binding := range bindings {
-				hostPort, err := strconv.ParseInt(binding.HostPort, 10, 16)
-				if err != nil {
-					continue
-				}
-
-				ports = append(ports, k3dPort{
-					Port:     int64(port.Int()),
-					HostIP:   binding.HostIP,
-					HostPort: hostPort,
-				})
-			}
-		}
-
-		newNodes[node.Name] = k3dNode{
-			Name:          node.Name,
-			Role:          string(node.Role),
-			Ports:         ports,
-			RuntimeLabels: node.RuntimeLabels,
-			NodeLabels:    node.K3sNodeLabels,
-			Networks:      node.Networks,
-			IP:            node.IP.IP.String(),
-		}
-	}
-
-	// For the purposes of this example code, hardcoding a response value to
-	// save into the Terraform state.
-	data.Id = data.ClusterName
-	data.Nodes = newNodes
-
-	diags = resp.State.Set(ctx, &data)
-	resp.Diagnostics.Append(diags...)
 }

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	provider "github.com/hashicorp/terraform-plugin-framework/provider"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 )
 
@@ -24,16 +26,21 @@ type k3dProvider struct {
 func (p *k3dProvider) Configure(ctx context.Context, req provider.ConfigureRequest, resp *provider.ConfigureResponse) {
 }
 
-func (p *k3dProvider) GetResources(ctx context.Context) (map[string]provider.ResourceType, diag.Diagnostics) {
-	return map[string]provider.ResourceType{
-		"k3d_cluster": k3dClusterType{},
-	}, nil
+func (p *k3dProvider) Metadata(ctx context.Context, req provider.MetadataRequest, resp *provider.MetadataResponse) {
+	resp.TypeName = "k3d"
+	resp.Version = p.version
 }
 
-func (p *k3dProvider) GetDataSources(ctx context.Context) (map[string]provider.DataSourceType, diag.Diagnostics) {
-	return map[string]provider.DataSourceType{
-		"k3d_nodes": k3dNodesDataSourceType{},
-	}, nil
+func (p *k3dProvider) DataSources(context.Context) []func() datasource.DataSource {
+	return []func() datasource.DataSource{
+		NewNodesDataSource,
+	}
+}
+
+func (p *k3dProvider) Resources(context.Context) []func() resource.Resource {
+	return []func() resource.Resource{
+		NewClusterResource,
+	}
 }
 
 func (p *k3dProvider) GetSchema(ctx context.Context) (tfsdk.Schema, diag.Diagnostics) {


### PR DESCRIPTION
Moving from v0.11.0 to v0.14.0. There were some major breaking changes in the plugin framework that needed accounting for in how we advertise resources and datasources to terraform.